### PR TITLE
Add basic FastAPI app with audit history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+sec_audi.db

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,21 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./sec_audi.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,97 @@
+from fastapi import FastAPI, Request, Depends, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session, joinedload
+import requests
+
+from . import models, database
+
+app = FastAPI()
+templates = Jinja2Templates(directory="app/templates")
+
+models.Base.metadata.create_all(bind=database.engine)
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard(request: Request, db: Session = Depends(database.get_db)):
+    servers = db.query(models.Server).all()
+    return templates.TemplateResponse("index.html", {"request": request, "servers": servers})
+
+
+@app.post("/servers")
+def create_server(
+    name: str = Form(...),
+    host: str = Form(...),
+    ssh_key: str = Form("") ,
+    db: Session = Depends(database.get_db),
+):
+    server = models.Server(name=name, host=host, ssh_key=ssh_key)
+    db.add(server)
+    db.commit()
+    return RedirectResponse("/", status_code=303)
+
+
+@app.post("/servers/{server_id}/audit")
+def run_audit(server_id: int, db: Session = Depends(database.get_db)):
+    server = db.query(models.Server).get(server_id)
+    report = f"# Audit report for {server.name}\nPlaceholder report"
+    rating = "Mittel"
+    audit = models.Audit(
+        server_id=server.id,
+        rating=rating,
+        report_markdown=report,
+        scorecard_json="{}",
+    )
+    db.add(audit)
+    db.commit()
+    return RedirectResponse(f"/audits/{audit.id}", status_code=303)
+
+
+@app.get("/settings", response_class=HTMLResponse)
+def settings(request: Request):
+    return templates.TemplateResponse("settings.html", {"request": request})
+
+
+@app.post("/settings")
+def save_settings(request: Request, host: str = Form(...), port: int = Form(...)):
+    request.app.state.ollama_host = host
+    request.app.state.ollama_port = port
+    return RedirectResponse("/settings", status_code=303)
+
+
+@app.get("/settings/models")
+def list_models(request: Request):
+    host = getattr(request.app.state, "ollama_host", "localhost")
+    port = getattr(request.app.state, "ollama_port", 11434)
+    try:
+        resp = requests.get(f"http://{host}:{port}/api/tags", timeout=5)
+        models_list = [m["name"] for m in resp.json().get("models", [])]
+    except Exception:
+        models_list = []
+    return {"models": models_list}
+
+
+@app.get("/audits", response_class=HTMLResponse)
+def audits(request: Request, db: Session = Depends(database.get_db)):
+    audits = (
+        db.query(models.Audit)
+        .options(joinedload(models.Audit.server))
+        .order_by(models.Audit.created_at.desc())
+        .all()
+    )
+    return templates.TemplateResponse(
+        "audits.html", {"request": request, "audits": audits}
+    )
+
+
+@app.get("/audits/{audit_id}", response_class=HTMLResponse)
+def audit_detail(audit_id: int, request: Request, db: Session = Depends(database.get_db)):
+    audit = (
+        db.query(models.Audit)
+        .options(joinedload(models.Audit.server))
+        .filter(models.Audit.id == audit_id)
+        .first()
+    )
+    return templates.TemplateResponse(
+        "audit_detail.html", {"request": request, "audit": audit}
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class Server(Base):
+    __tablename__ = "servers"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    host = Column(String)
+    ssh_key = Column(Text, nullable=True)
+
+    audits = relationship("Audit", back_populates="server")
+
+
+class Audit(Base):
+    __tablename__ = "audits"
+    id = Column(Integer, primary_key=True, index=True)
+    server_id = Column(Integer, ForeignKey("servers.id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    rating = Column(String)
+    report_markdown = Column(Text)
+    scorecard_json = Column(Text)
+
+    server = relationship("Server", back_populates="audits")

--- a/app/templates/audit_detail.html
+++ b/app/templates/audit_detail.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-2">Audit für {{ audit.server.name }}</h1>
+<p class="mb-2">Datum: {{ audit.created_at }} | Bewertung: {{ audit.rating }}</p>
+<pre class="whitespace-pre-wrap border p-4">{{ audit.report_markdown }}</pre>
+{% endblock %}

--- a/app/templates/audits.html
+++ b/app/templates/audits.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Audit-Verlauf</h1>
+<table class="table-auto w-full">
+  <thead>
+    <tr><th class="px-2">Server</th><th class="px-2">Datum</th><th class="px-2">Bewertung</th></tr>
+  </thead>
+  <tbody>
+  {% for audit in audits %}
+    <tr class="border-t">
+      <td class="px-2"><a href="/audits/{{ audit.id }}" class="text-blue-600">{{ audit.server.name }}</a></td>
+      <td class="px-2">{{ audit.created_at }}</td>
+      <td class="px-2">{{ audit.rating }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <title>SecAudi</title>
+</head>
+<body class="p-4">
+<nav class="mb-4 space-x-4">
+  <a href="/">Dashboard</a>
+  <a href="/audits">Audit-Verlauf</a>
+  <a href="/settings">Einstellungen</a>
+</nav>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Server Dashboard</h1>
+<form method="post" action="/servers" class="mb-4 space-x-2">
+  <input name="name" placeholder="Servername" class="border px-2" />
+  <input name="host" placeholder="Host" class="border px-2" />
+  <button type="submit" class="bg-blue-500 text-white px-3 py-1">Hinzufügen</button>
+</form>
+<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+{% for server in servers %}
+  <div class="border p-4">
+    <h2 class="font-bold">{{ server.name }}</h2>
+    <p>{{ server.host }}</p>
+    <form method="post" action="/servers/{{ server.id }}/audit">
+      <button class="mt-2 bg-green-600 text-white px-2 py-1">Audit erstellen</button>
+    </form>
+  </div>
+{% endfor %}
+</div>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Einstellungen</h1>
+<form method="post" class="mb-4 space-x-2">
+  <input name="host" placeholder="Ollama Host" value="{{ request.app.state.ollama_host or '' }}" class="border px-2" />
+  <input name="port" placeholder="Port" value="{{ request.app.state.ollama_port or '' }}" class="border px-2" />
+  <button type="submit" class="bg-blue-500 text-white px-3 py-1">Speichern</button>
+</form>
+<select id="model-select" class="border px-2 py-1"></select>
+<script>
+async function loadModels(){
+  const res = await fetch('/settings/models');
+  const data = await res.json();
+  const select = document.getElementById('model-select');
+  select.innerHTML = '';
+  data.models.forEach(m => {
+    const opt = document.createElement('option');
+    opt.value = m;
+    opt.textContent = m;
+    select.appendChild(opt);
+  });
+}
+loadModels();
+</script>
+{% endblock %}

--- a/readm.me
+++ b/readm.me
@@ -1,1 +1,8 @@
-#test
+# SecAudi
+
+Simple FastAPI-based web application for Linux server audits with a Tailwind CSS frontend.
+
+## Features
+- Dashboard to add servers and trigger audits
+- Settings page to configure Ollama connection and fetch available models
+- Audit history storing reports and scorecards in SQLite


### PR DESCRIPTION
## Summary
- set up FastAPI backend with SQLite models for servers and audits
- add Tailwind-based templates for dashboard, settings, and audit history
- include endpoint to fetch Ollama models and store audit reports

## Testing
- `python -m py_compile app/database.py app/models.py app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6899dbca830c8322acc9a470df919ba0